### PR TITLE
Discord RPC

### DIFF
--- a/config.py
+++ b/config.py
@@ -155,6 +155,7 @@ class Config:
     shader_file_name = "none.glsl"
     do_color_bounce_pegs = False
     do_particles_on_bounce = True
+    discordrpc = False
 
     # settings that are not configurable (yet)
     backtrack_chance: Optional[float] = 0.02
@@ -180,7 +181,7 @@ class Config:
                   "square_speed", "volume", "music_offset", "direction_change_chance", "hp_drain_rate", "theatre_mode",
                   "particle_trail", "shader_file_name", "do_color_bounce_pegs", 
                   "do_particles_on_bounce", "language",
-                  "SCREEN_WIDTH", "SCREEN_HEIGHT"]
+                  "SCREEN_WIDTH", "SCREEN_HEIGHT", "discordrpc"]
 
     # glow effect, for dark_modern only for now
     square_glow = True

--- a/config.py
+++ b/config.py
@@ -155,7 +155,7 @@ class Config:
     shader_file_name = "none.glsl"
     do_color_bounce_pegs = False
     do_particles_on_bounce = True
-    discordrpc = False
+    discord_rpc = False
 
     # settings that are not configurable (yet)
     backtrack_chance: Optional[float] = 0.02
@@ -181,7 +181,7 @@ class Config:
                   "square_speed", "volume", "music_offset", "direction_change_chance", "hp_drain_rate", "theatre_mode",
                   "particle_trail", "shader_file_name", "do_color_bounce_pegs", 
                   "do_particles_on_bounce", "language",
-                  "SCREEN_WIDTH", "SCREEN_HEIGHT", "discordrpc"]
+                  "SCREEN_WIDTH", "SCREEN_HEIGHT", "discor_rpc"]
 
     # glow effect, for dark_modern only for now
     square_glow = True

--- a/config.py
+++ b/config.py
@@ -181,7 +181,7 @@ class Config:
                   "square_speed", "volume", "music_offset", "direction_change_chance", "hp_drain_rate", "theatre_mode",
                   "particle_trail", "shader_file_name", "do_color_bounce_pegs", 
                   "do_particles_on_bounce", "language",
-                  "SCREEN_WIDTH", "SCREEN_HEIGHT", "discor_rpc"]
+                  "SCREEN_WIDTH", "SCREEN_HEIGHT", "discord_rpc"]
 
     # glow effect, for dark_modern only for now
     square_glow = True

--- a/configpage.py
+++ b/configpage.py
@@ -137,16 +137,16 @@ class ConfigPage:
 
         # audio and general settings
 
-        self.s_discordrpc_label = pgui.elements.UILabel(
+        self.s_discord_rpc_label = pgui.elements.UILabel(
             relative_rect=pygame.Rect((Config.SCREEN_WIDTH * 5 / 10, Config.SCREEN_HEIGHT * 9 // 10 - 30, 300, 30)),
             text="Discord RPC",
             manager=self.ui_manager
         )
 
-        self.s_discordrpc = pgui.elements.UIDropDownMenu(
+        self.s_discord_rpc = pgui.elements.UIDropDownMenu(
             ["Off", "On"],
             relative_rect=pygame.Rect((Config.SCREEN_WIDTH * 5 / 10, Config.SCREEN_HEIGHT * 9 // 10, 300, 30)),
-            starting_option=["Off", "On"][int(Config.discordrpc)],
+            starting_option=["Off", "On"][int(Config.discord_rpc)],
             manager=self.ui_manager
         )
 
@@ -366,8 +366,8 @@ class ConfigPage:
             if event.ui_element == self.s_resolution:
                 event.text = event.text.split("x")
                 Config.SCREEN_WIDTH, Config.SCREEN_HEIGHT = int(event.text[0]), int(event.text[1])
-            if event.ui_element == self.s_discordrpc:
-                Config.discordrpc = bool(["Off", "On"].index(event.text))
+            if event.ui_element == self.s_discord_rpc:
+                Config.discord_rpc = bool(["Off", "On"].index(event.text))
 
         if event.type == pgui.UI_TEXT_ENTRY_CHANGED:
             if event.ui_element == self.s_seed:

--- a/configpage.py
+++ b/configpage.py
@@ -137,6 +137,19 @@ class ConfigPage:
 
         # audio and general settings
 
+        self.s_discordrpc_label = pgui.elements.UILabel(
+            relative_rect=pygame.Rect((Config.SCREEN_WIDTH * 5 / 10, Config.SCREEN_HEIGHT * 9 // 10 - 30, 300, 30)),
+            text="Discord RPC",
+            manager=self.ui_manager
+        )
+
+        self.s_discordrpc = pgui.elements.UIDropDownMenu(
+            ["Off", "On"],
+            relative_rect=pygame.Rect((Config.SCREEN_WIDTH * 5 / 10, Config.SCREEN_HEIGHT * 9 // 10, 300, 30)),
+            starting_option=["Off", "On"][int(Config.discordrpc)],
+            manager=self.ui_manager
+        )
+
         self.s_game_volume = pgui.elements.UIHorizontalSlider(
             relative_rect=pygame.Rect((Config.SCREEN_WIDTH * 5 / 10, Config.SCREEN_HEIGHT // 10, 300, 30)),
             start_value=Config.volume,
@@ -353,6 +366,8 @@ class ConfigPage:
             if event.ui_element == self.s_resolution:
                 event.text = event.text.split("x")
                 Config.SCREEN_WIDTH, Config.SCREEN_HEIGHT = int(event.text[0]), int(event.text[1])
+            if event.ui_element == self.s_discordrpc:
+                Config.discordrpc = bool(["Off", "On"].index(event.text))
 
         if event.type == pgui.UI_TEXT_ENTRY_CHANGED:
             if event.ui_element == self.s_seed:

--- a/discord_rpc.py
+++ b/discord_rpc.py
@@ -1,0 +1,11 @@
+import discordrpc
+
+rpc = discordrpc.RPC(app_id=1217556150325743757)
+
+def setrpc(song):
+    rpc.set_activity(
+        state=f"Playing song: {song}",
+)
+
+def startrpc():
+    rpc.run

--- a/main.py
+++ b/main.py
@@ -223,7 +223,7 @@ def main():
         Config.dt = clock.tick(FRAMERATE) / 1000
 
     # setup discord rpc
-    if Config.discordrpc:
+    if Config.discord_rpc:
         startrpc()
 
     pygame.quit()

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from game import Game
 from configpage import ConfigPage
 from songselector import SongSelector
 from errorscreen import ErrorScreen
+from discord_rpc import *
 from os import getcwd
 from platform import system as get_os
 from config import save_to_file
@@ -220,6 +221,11 @@ def main():
         update_screen(screen, glsl_program, render_object)
 
         Config.dt = clock.tick(FRAMERATE) / 1000
+
+    # setup discord rpc
+    if Config.discordrpc:
+        startrpc()
+
     pygame.quit()
     save_to_file()
 

--- a/songselector.py
+++ b/songselector.py
@@ -1,4 +1,5 @@
 from utils import *
+from discord_rpc import setrpc
 from os import listdir
 from os.path import isfile, join
 from zipfile import ZipFile
@@ -180,6 +181,7 @@ class SongSelector:
                         pygame.mixer.music.set_volume(Config.volume/100)
                         pygame.mixer.music.play()
                         self.selected_index = index
+                        setrpc(song.name)
                         return
                 if self.play_button_rect.collidepoint(pygame.mouse.get_pos()):
                     if self.selected_index+1:
@@ -187,6 +189,7 @@ class SongSelector:
                         pygame.mixer.music.stop()
                         self.active = False
                         return self.songs[self.selected_index]
+
                 if self.back_button_rect.collidepoint(pygame.mouse.get_pos()):
                     play_sound("select.mp3")
                     self.active = False


### PR DESCRIPTION
This pull request implements Discord RPC support. When enabled, the current level and game status is displayed in Discord on the user's profile. 

This is an initial implementation and there's more work to be done.

Currently, the level begins being displayed when the option is clicked in the song selection menu. I can't figure out how to get it displayed after the level is loaded instead.

This feature can be enabled and disabled through the settings menu. 

**This pull request has been tested thoroughly and works as intended**

- [ ] RPC for browing the menus
- [ ] RPC for selecting a level/song
- [ ] RPC displaying details of current level after one has been loaded
- [ ] Show some information while the level is being played