### PR TITLE
Update shaders to modern OpenGL API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 assets/settings.json
 dist
 main.spec
+venv

--- a/assets/shaders/art.glsl
+++ b/assets/shaders/art.glsl
@@ -13,7 +13,7 @@ float gamma( in float value, in float g ) {
 }
 void main(void) {
 	
-	vec4 color = texture2D( tex, uvs );
+	vec4 color = texture( tex, uvs );
 	float r = color.r;
 	float g = color.g;
 	float b = color.b;
@@ -31,6 +31,6 @@ void main(void) {
 	b = gamma( b, 0.87 ); 
 	float yL = .2126 * color.r + .7152 * color.g + .0722 * color.b;
 	r += yL; g += yL; b += yL;
-	gl_FragColor = vec4( r, g, b, color.a );
+	f_color = vec4( r, g, b, color.a );
 	
 }

--- a/assets/shaders/ascii.glsl
+++ b/assets/shaders/ascii.glsl
@@ -14,7 +14,7 @@ vec4 lookupASCII(float asciiValue) {
 
 	pos = pos / vec2(2048.0, 16.0);
 	pos.x += asciiValue;
-	return vec4(texture2D(asciipng,pos).rgb, 1.0);
+	return vec4(texture(asciipng,pos).rgb, 1.0);
 
 }
 
@@ -27,13 +27,13 @@ void main(void) {
 	for (float x=0.0;x<fontSize.x;x++){
 		for (float y=0.0;y<fontSize.y;y++){
 			vec2 offset = vec2(x,y);
-			sum += texture2D(tex,uvClamped+(offset*invViewport));
+			sum += texture(tex,uvClamped+(offset*invViewport));
 		}
 	}
 	vec4 avarage = sum / vec4(fontSize.x*fontSize.y);
 	float brightness = (avarage.x+avarage.y+avarage.z)*0.33333;
 	vec4 clampedColor = floor(avarage*8.0)/8.0;
 	float asciiChar = floor((1.0-brightness)*256.0)/256.0;
-	gl_FragColor = clampedColor*lookupASCII(asciiChar);
+	f_color = clampedColor*lookupASCII(asciiChar);
 
 }

--- a/assets/shaders/barrel-blur.glsl
+++ b/assets/shaders/barrel-blur.glsl
@@ -17,20 +17,20 @@ void main() {
 
 	vec2 uv=uvs;
 
-	vec4 a1=texture2D(tex, barrelDistortion(uv,0.0));
-	vec4 a2=texture2D(tex, barrelDistortion(uv,0.2));
-	vec4 a3=texture2D(tex, barrelDistortion(uv,0.4));
-	vec4 a4=texture2D(tex, barrelDistortion(uv,0.6));
+	vec4 a1=texture(tex, barrelDistortion(uv,0.0));
+	vec4 a2=texture(tex, barrelDistortion(uv,0.2));
+	vec4 a3=texture(tex, barrelDistortion(uv,0.4));
+	vec4 a4=texture(tex, barrelDistortion(uv,0.6));
 	
-	vec4 a5=texture2D(tex, barrelDistortion(uv,0.8));
-	vec4 a6=texture2D(tex, barrelDistortion(uv,1.0));
-	vec4 a7=texture2D(tex, barrelDistortion(uv,1.2));
-	vec4 a8=texture2D(tex, barrelDistortion(uv,1.4));
+	vec4 a5=texture(tex, barrelDistortion(uv,0.8));
+	vec4 a6=texture(tex, barrelDistortion(uv,1.0));
+	vec4 a7=texture(tex, barrelDistortion(uv,1.2));
+	vec4 a8=texture(tex, barrelDistortion(uv,1.4));
 	
-	vec4 a9=texture2D(tex, barrelDistortion(uv,1.6));
-	vec4 a10=texture2D(tex, barrelDistortion(uv,1.8));
-	vec4 a11=texture2D(tex, barrelDistortion(uv,2.0));
-	vec4 a12=texture2D(tex, barrelDistortion(uv,2.2));
+	vec4 a9=texture(tex, barrelDistortion(uv,1.6));
+	vec4 a10=texture(tex, barrelDistortion(uv,1.8));
+	vec4 a11=texture(tex, barrelDistortion(uv,2.0));
+	vec4 a12=texture(tex, barrelDistortion(uv,2.2));
 
 	vec4 tx=(a1+a2+a3+a4+a5+a6+a7+a8+a9+a10+a11+a12)/12.0;
 	f_color = vec4(tx.rgb, 1);

--- a/assets/shaders/bloom.glsl
+++ b/assets/shaders/bloom.glsl
@@ -14,22 +14,22 @@ void main()
    {
         for ( int j = -3; j < 3; j++)
         {
-            sum += texture2D(tex, texcoord + vec2(j, i)*0.0006) * 0.13;
+            sum += texture(tex, texcoord + vec2(j, i)*0.0006) * 0.13;
         }
    }
-       if (texture2D(tex, texcoord).r < 0.3)
+       if (texture(tex, texcoord).r < 0.3)
     {
-       f_color = sum*sum*0.012 + texture2D(tex, texcoord);
+       f_color = sum*sum*0.012 + texture(tex, texcoord);
     }
     else
     {
-        if (texture2D(tex, texcoord).r < 0.5)
+        if (texture(tex, texcoord).r < 0.5)
         {
-            f_color = sum*sum*0.009 + texture2D(tex, texcoord);
+            f_color = sum*sum*0.009 + texture(tex, texcoord);
         }
         else
         {
-            f_color = sum*sum*0.0075 + texture2D(tex, texcoord);
+            f_color = sum*sum*0.0075 + texture(tex, texcoord);
         }
     }
 }

--- a/assets/shaders/chromatic-aberration.glsl
+++ b/assets/shaders/chromatic-aberration.glsl
@@ -52,5 +52,5 @@ void main()
 		sumcol += w * texture( tex, barrelDistortion(uv, 0.7 * max_distort*t ) );
 	}
 		
-	gl_FragColor = sumcol / sumw;
+	f_color = sumcol / sumw;
 }

--- a/assets/shaders/rgbsplit.glsl
+++ b/assets/shaders/rgbsplit.glsl
@@ -16,6 +16,6 @@ void main() {
 	vec4 c2 = texture( tex, uvs - value );
 	vec4 c3 = texture( tex, uvs );
 
-	gl_FragColor = vec4( c1.r, c2.g, c3.b, c1.a + c2.a + c3.b );
+	f_color = vec4( c1.r, c2.g, c3.b, c1.a + c2.a + c3.b );
 
 }


### PR DESCRIPTION
I'm on an M1 Mac and I noticed that the alternative shaders weren't working--they were throwing errors about unknown identifiers like `gl_FragColor` and `texture2D`. Looks like [OpenGL 3.30 deprecated texture2D and the predefined gl_FragColor variable.](https://registry.khronos.org/OpenGL/specs/gl/GLSLangSpec.3.30.pdf)

I replaced texture2D with texture, because the APIs appear drop-in compatible. As for gl_FragColor, it looks like most of these shaders were built with those new APIs in mind, because they had declared an out variable f_color. I just used that instead. All of the shaders work now, at least on the few machines I tested.
